### PR TITLE
Fix license inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,4 @@ All notable changes to this project will be documented in this file. The format 
 - Sentry error monitoring setup
 - GitHub Actions CI (Node 18/20 with pnpm cache)
 - Husky pre-push hooks, ESLint, Prettier, Vitest
-- License (ISC) and contributing guidelines 
+- License (MIT) and contributing guidelines

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,21 @@
-ISC License
+MIT License
 
 Copyright (c) 2025 Mahardika Team
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE. 
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ When creating new components, follow these guidelines:
 
 ## 📄 License
 
-ISC License
+MIT License
 
 ## 🏢 About Mahardika
 


### PR DESCRIPTION
## Summary
- switch to the MIT License
- update CHANGELOG and README

## Testing
- `pnpm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861231cd3b08320a775512c0674f34a